### PR TITLE
Fix audio service name

### DIFF
--- a/v4w-patcher.bat
+++ b/v4w-patcher.bat
@@ -77,7 +77,7 @@ if "%CMVAR%"=="2" (
 )
 if "%CMVAR%"=="3" (
 	call:BANNER
-	powershell -command "Restart-Service -DisplayName 'Windows Audio' -Confirm"
+	powershell -command "Restart-Service -Name Audiosrv -Confirm"
 	goto:CHOICE_MENU
 )
 


### PR DESCRIPTION
The display name was being used to identify the audio service, so if the Windows language was different, the script would break.

Now it's using the proper service name.